### PR TITLE
update 4:3 5:4 box fix

### DIFF
--- a/autoexec.cfg
+++ b/autoexec.cfg
@@ -17,8 +17,8 @@ fps_max 0
 cl_fovScale "1.55" //1.55 is 110 fov
 ////////////////////////////////////////////////////
 //4:3 5:4 box fix
-mat_letterbox_aspect_goal "1.33"
-mat_letterbox_aspect_threshold "1.33"
+mat_letterbox_aspect_goal "0.0"
+mat_letterbox_aspect_threshold "0.0"
 ////////////////////////////////////////////////////
 //testing network commands
 //cl_interp 0


### PR DESCRIPTION
This is just a treshold. Should Be 0 to work on any resolution.
1.33 leaves black bars on higher 4:3 resolutions.